### PR TITLE
Assignt the OperatorGroup to a namespace, and avoid specifying the startingCSV for the operator

### DIFF
--- a/aap-operator/base/ansible-automation-platform-og.yaml
+++ b/aap-operator/base/ansible-automation-platform-og.yaml
@@ -7,4 +7,7 @@ metadata:
       AnsibleJob.v1alpha1.tower.ansible.com,AutomationController.v1beta1.automationcontroller.ansible.com,AutomationControllerBackup.v1beta1.automationcontroller.ansible.com,AutomationControllerRestore.v1beta1.automationcontroller.ansible.com,AutomationHub.v1beta1.automationhub.ansible.com,AutomationHubBackup.v1beta1.automationhub.ansible.com,AutomationHubRestore.v1beta1.automationhub.ansible.com,JobTemplate.v1alpha1.tower.ansible.com
   name: ansible-automation-platform
   namespace: ansible-automation-platform
-spec: {}
+spec:
+  targetNamespaces:
+    - ansible-automation-platform
+...

--- a/aap-operator/base/ansible-automation-platform-operator-sub.yaml
+++ b/aap-operator/base/ansible-automation-platform-operator-sub.yaml
@@ -12,5 +12,5 @@ spec:
   name: ansible-automation-platform-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  #startingCSV: aap-operator.v2.1.1-0.1645831476
+  # startingCSV: aap-operator.v2.1.1-0.1645831476
 ...

--- a/aap-operator/base/ansible-automation-platform-operator-sub.yaml
+++ b/aap-operator/base/ansible-automation-platform-operator-sub.yaml
@@ -12,4 +12,5 @@ spec:
   name: ansible-automation-platform-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: aap-operator.v2.1.1+0.1647905319
+  #startingCSV: aap-operator.v2.1.1-0.1645831476
+...

--- a/auto-hub/base/auto-automationhub.yaml
+++ b/auto-hub/base/auto-automationhub.yaml
@@ -34,7 +34,7 @@ spec:
   loadbalancer_protocol: http
   resource_manager:
     replicas: 1
-  route_host: automationhub-dev.apps.cluster-7987.sandbox19.opentlc.com
+  # route_host: automationhub-dev.apps.cluster-7987.sandbox19.opentlc.com
   storage_type: S3
   worker:
     replicas: 2


### PR DESCRIPTION
Assign the OperatorGroup to a namespace, and avoid specifying the startingCSV for the operator